### PR TITLE
Pytest Conversion 2

### DIFF
--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -18,11 +18,9 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    
-    build-matrix:
-        strategy:
-        matrix:
-            python-version: ["3.10", "2.7"]
+    strategy:
+    matrix:
+        python-version: ["3.10", "2.7"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -18,16 +18,21 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    strategy:
-        matrix:
-            python-version: ["3.10", "2.7"]
+    services:
+        python2:
+            image: python:2.7.16
+        python3:
+            image: python:3.10.13
+    # strategy:
+    #     matrix:
+    #         python-version: ["3.10", "2.7"]
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
-      with:
-        python-version: ${{ matrix.python-version }}
+    # - uses: actions/checkout@v4
+    # - name: Set up Python ${{ matrix.python-version }}
+    #   uses: actions/setup-python@v3
+    #   with:
+    #     python-version: ${{ matrix.python-version }}
     - name: Display Current Python Version
       run: python -c "import sys; print(sys.version)"
     - name: Install dependencies

--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -28,7 +28,7 @@ jobs:
     #         python-version: ["3.10", "2.7"]
 
     steps:
-    # - uses: actions/checkout@v4
+    - uses: actions/checkout@v4
     # - name: Set up Python ${{ matrix.python-version }}
     #   uses: actions/setup-python@v3
     #   with:

--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a single version of Python
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
-name: Python application
+name: PyNE
 
 on:
   push:
@@ -18,13 +18,20 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    
+    build-matrix:
+        strategy:
+        matrix:
+            python-version: ["3.10", "2.7"]
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.10
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v3
       with:
-        python-version: "3.10"
+        python-version: ${{ matrix.python-version }}
+    - name: Display Current Python Version
+      run: python -c "import sys; print(sys.version)"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -18,21 +18,16 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    services:
-        python2:
-            image: python:2.7.16
-        python3:
-            image: python:3.10.13
-    # strategy:
-    #     matrix:
-    #         python-version: ["3.10", "2.7"]
+    strategy:
+      matrix:
+         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4
-    # - name: Set up Python ${{ matrix.python-version }}
-    #   uses: actions/setup-python@v3
-    #   with:
-    #     python-version: ${{ matrix.python-version }}
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+         python-version: ${{ matrix.python-version }}
     - name: Display Current Python Version
       run: python -c "import sys; print(sys.version)"
     - name: Install dependencies

--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+         python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/on_push.yml
+++ b/.github/workflows/on_push.yml
@@ -19,8 +19,8 @@ jobs:
 
     runs-on: ubuntu-latest
     strategy:
-    matrix:
-        python-version: ["3.10", "2.7"]
+        matrix:
+            python-version: ["3.10", "2.7"]
 
     steps:
     - uses: actions/checkout@v4

--- a/pyrk/db/tests/test_database.py
+++ b/pyrk/db/tests/test_database.py
@@ -1,19 +1,18 @@
 from pyrk.db import database as d
 
-import unittest
-
+import pytest
 
 def dictfunc():
     return {'t0': 2}
 
+class TestDatabase:
 
-class DatabaseTest(unittest.TestCase):
-    def setUp(self):
+    @pytest.fixture(autouse=True)
+    def resource(self):
         "set up test fixtures"
         self.a = d.Database(mode='w')
         self.custom = d.Database(filepath='testfile.h5', mode='w')
-
-    def tearDown(self):
+        yield "resource"
         "tear down test fixtures"
         self.a.close_db()
         self.a.delete_db()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 matplotlib
-numpy
+numpy==1.26.4
 scipy
 pint
 tables


### PR DESCRIPTION
- Finished moving nosetest to pytest (some nosetest framework was left behind in the database tests, successfully converted over to pytest).
- Updated the workflow to only test in Python 3.9, 3.10, 3.11 and 3.12. Support for 2.7 ended long ago, and support for 3.8 will end in October.
- Fixed the numpy version in requirements.txt to 1.26.4, as it's the latest version of numpy that doesn't have an incompatibility with pandas (numpy 2.x seems to have compatibility issues for the time being).